### PR TITLE
Django 3.2 testdata backport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.0, 3.1]
+        django-version: [2.2, 3.0, 3.1, 3.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.0, 3.1, 3.2]
+        django-version: [2.1, 2.2, 3.0, 3.1, 3.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/django_testing_utils/mixins.py
+++ b/django_testing_utils/mixins.py
@@ -135,4 +135,4 @@ class BaseTestCase(TimeMixin, TestCase, metaclass=BaseTestCaseMeta):
             obj = self.reload(obj)
         for k, v in kwargs.items():
             value = getattr(obj, k)
-            self.assertEqual(value, v)
+            self.assertEqual(value, v, k)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django==3.1.7
+Django==3.2

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     author_email='zimbler@gmail.com',
     description='Utils for Django admin testing',
     install_requires=[
-        'Django>=2.1,<3.2',
+        'Django>=2.1,<3.3',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -79,6 +79,7 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
+        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',

--- a/testproject/testapp/tests/test_mixins.py
+++ b/testproject/testapp/tests/test_mixins.py
@@ -8,21 +8,87 @@ class BaseTestCaseMetaTestCase(mixins.BaseTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.project = models.Project.objects.create(name='project')
-        cls.project2 = models.Project.objects.create(name='project2')
-        cls.forget_object(cls.project2)
-        cls.project2.delete()
+        cls.project = models.Project.objects.create(name='initial')
 
-    def test_1_first(self):
-        """ Modify something in memory."""
-        self.project.name = 'modified'
-        self.project.save()
+    def test_update_object(self):
+        """ update_object updates object in database only"""
+        self.update_object(self.project, name='modified')
 
-        self.project2.name = 'modified2'
+        self.assertEqual(self.project.name, 'initial')
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.name, 'modified')
 
-    def test_2_second(self):
-        """ class attributes are reset correctly."""
-        # This test fill pass only if running whole test case
-        self.assertEqual(self.project.name, "project")
-        # forgotten object is in modified state
-        self.assertEqual(self.project2.name, "modified2")
+    def test_reload(self):
+        """ reload fetches actual object version from db."""
+        self.update_object(self.project, name='modified')
+
+        project = self.reload(self.project)
+        self.assertEqual(self.project.name, 'initial')
+        self.assertEqual(project.name, 'modified')
+
+    def test_assert_object_fields(self):
+        """ assert_object_fields reloads object and checks for equality."""
+        # collecting assert message
+        with self.assertRaises(AssertionError) as ctx:
+            self.assertEqual(self.project.name, 'wrong', 'name')
+
+        args = ctx.exception.args
+
+        with self.assertRaises(AssertionError)as ctx:
+            self.assert_object_fields(self.project, name='wrong')
+
+        self.assertEqual(ctx.exception.args, args)
+
+        self.assert_object_fields(self.project, name='initial')
+
+    def test_refresh_objects(self):
+        """
+        refresh_objects updates from db each django model instance created
+        in setUpTestData.
+        """
+        self.project.name = 'changed'
+
+        self.refresh_objects()
+
+        self.assertEqual(self.project.name, 'initial')
+
+    def test_forget_object(self):
+        """
+        forget_object removes a django model instance from saved instances
+        """
+        self.project.name = 'changed'
+
+        self.forget_object(self.project)
+
+        self.refresh_objects()
+        # self.project not reloaded from db, because it's removed from saved
+        # object list
+        self.assertEqual(self.project.name, 'changed')
+
+
+class SetUpTestDataResetTestCase(mixins.BaseTestCase):
+    """
+    Ensures that objects created in setUpTestData are reset between tests
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.project = models.Project.objects.create(name='initial')
+        cls.project2 = models.Project.objects.create(name='first')
+
+    def test_1_change_something(self):
+        """
+        First test in testcase that pollutes class attribute
+        """
+        # change in-memory
+        self.project.name = 'changed'
+        # change in-db
+        self.update_object(self.project2, name='altered')
+
+    def test_2_assert_object_reset(self):
+        """
+        Second test in testcase that checks that polluted object is reset
+        between tests.
+        """
+        self.assertEqual(self.project.name, 'initial')
+        self.assertEqual(self.project2.name, 'first')


### PR DESCRIPTION
This backports django-3.2 behavior for objects created in `setUpTestData`