### PR TITLE
Extend mocking timezone.now

### DIFF
--- a/django_testing_utils/mixins.py
+++ b/django_testing_utils/mixins.py
@@ -34,10 +34,6 @@ class MockedDateTime(datetime):
     def utcnow(cls):  # type: ignore
         # noinspection PyUnresolvedReferences
         return timezone.utc.normalize(timezone.now())
-    #
-    # @classmethod
-    # def now(cls, tz=None):
-    #     return timezone.now().astimezone(tz)
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/django_testing_utils/mixins.py
+++ b/django_testing_utils/mixins.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, tzinfo
 from functools import wraps
-from typing import TypeVar, Union, Tuple, Any, TYPE_CHECKING, Dict, cast, Type
+from typing import TypeVar, Union, Tuple, Any, TYPE_CHECKING, Dict, cast, Type, \
+    Optional
 from unittest import mock
 
 from django.db import models
@@ -74,7 +75,7 @@ class TimeMixin(TimeMixinTarget):
         self.timezone_datetime_patcher.stop()
         self.now_patcher.stop()
 
-    def get_now(self, tz=None) -> datetime:
+    def get_now(self, tz: Optional[tzinfo] = None) -> datetime:
         return self.now.astimezone(tz)
 
 

--- a/testproject/testapp/tests/test_mixins.py
+++ b/testproject/testapp/tests/test_mixins.py
@@ -1,12 +1,15 @@
 import io
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+from django.utils.timezone import now as tested_now
 
 from django_testing_utils import mixins
 from testapp import models
 
 
 class MixinBaseTestCase(mixins.BaseTestCase):
+    project: models.Project
 
     @classmethod
     def setUpTestData(cls):
@@ -127,3 +130,12 @@ class SetUpTestDataResetTestCase(MixinBaseTestCase):
         """
         self.assertEqual(self.project.name, 'initial')
         self.assertEqual(self.project2.name, 'first')
+
+
+class TimeMixinTestCase(mixins.BaseTestCase):
+
+    def test_timezone_now(self):
+        self.assertEqual(timezone.now(), self.now)
+
+    def test_timezone_datetime_now(self):
+        self.assertEqual(tested_now(), self.now)


### PR DESCRIPTION
Support mocking timezone.now results even if imported as now to another module

Closes #43